### PR TITLE
Update lunarlander.s

### DIFF
--- a/asm/KIM-1/TheFirstBookOfKIM/Games/Lunar Lander/lunarlander.s
+++ b/asm/KIM-1/TheFirstBookOfKIM/Games/Lunar Lander/lunarlander.s
@@ -130,7 +130,7 @@ RETRN:  RTS
 NUMBER: TAX
         LDA     THRUST          ; test; is motor off?
         BEQ     RETRN           ; yes, ignore key
-        STA     THRUST          ; no, store thrust
+        STX     THRUST          ; no, store thrust
 
 ; calculate accel as thrust minus 5
 


### PR DESCRIPTION
From label NUMBER: 'Accu' is stored in X, so if motor is not off, X should be stored to THRUST